### PR TITLE
Changes for LH2

### DIFF
--- a/GameData/SMURFF/SMURFF.cfg
+++ b/GameData/SMURFF/SMURFF.cfg
@@ -109,6 +109,26 @@ SMURFFCONFIG
 	@argonreservefactor /= #$argonfactor$
 	@argonreservefactor *= #$argonfracstd$
 	
+	// ** LH2 ** // for Nertea's CryoEngines/CryoTanks
+	
+	LH2fracstd = 0.352858151 //Fraction for LOX lifting tanks
+	
+	LH2factor = 2 // Halving the ratio for now, tank mass starts at 35% of fuel mass, and boiloff is in play
+	@LH2factor != #$tanklever$
+	
+	LH2minusfactor = 1
+	@LH2minusfactor /= #$LH2factor$
+	@LH2minusfactor -= 1
+	@LH2minusfactor *= -1
+	
+	LH2massfactor = 1
+	@LH2massfactor = #$LH2minusfactor$
+	@LH2massfactor *= #$LH2fracstd$
+	
+	LH2reservefactor = 1
+	@LH2reservefactor /= #$LH2factor$
+	@LH2reservefactor *= #$LH2fracstd$
+	
 	// ** SWITCHABLE
 	
 	switchablefactor = 2
@@ -187,6 +207,12 @@ SMURFFCONFIG
 }
 
 @PART[*]:HAS[@RESOURCE[ArgonGas],~SMURFFExclude[*rue]]:FOR[zSMURFF] 
+{
+	%reservedmass = 0
+	%initialmass = #$mass$
+}
+
+@PART[*]:HAS[@RESOURCE[LqdHydrogen],~SMURFFExclude[*rue]]:FOR[zSMURFF]  //adding LH2
 {
 	%reservedmass = 0
 	%initialmass = #$mass$
@@ -293,6 +319,21 @@ SMURFFCONFIG
 	%MODULE[ModuleSMURFF]{ }
 }
 
+//This is appropriate for Lifting Tanks, which have no cryogenics; but for CryoTanks, which have active cooling, a different mass factor is needed
+@PART[*]:HAS[@RESOURCE[LqdHydrogen],~SMURFFExclude[*rue]]:FOR[zSMURFF] //for Cryogenic Tanks, this is appropriate for Lifting Tanks, which have no cryogenics,
+{
+	%resourcemass = #$RESOURCE[LqdHydrogen]/maxAmount$
+	@resourcemass *= #$@RESOURCE_DEFINITION[LqdHydrogen]/density$ //In case the density changes -- it shouldn't, but why tempt fate?
+	@resourcemass *= #$@SMURFFCONFIG/LH2massfactor$
+	@mass -= #$resourcemass$
+	@resourcemass /= #$@SMURFFCONFIG/LH2massfactor$
+	@resourcemass *= #$@SMURFFCONFIG/LH2reservefactor$
+	@reservedmass += #$resourcemass$
+	-resourcemass = delete
+	
+	%MODULE[ModuleSMURFF]{ }
+}
+
 @PART[*]:HAS[@RESOURCE[SolidFuel],~SMURFFExclude[*rue]]:FOR[zSMURFF]
 {
 	%resourcemass = #$RESOURCE[SolidFuel]/maxAmount$
@@ -384,6 +425,8 @@ SMURFFCONFIG
 	
 	%MODULE[ModuleSMURFF]{ }
 }
+
+// May need to add new config for Nertea's new LH2 tanks with active cooling
 
 // **** PODS AND HEAT SHIELDS ****
 
@@ -525,13 +568,26 @@ SMURFFCONFIG
 	@tankMass2 -= #$massBuff$
 	@tankMass3 -= #$massBuff$
 	
+	// Nertea has implemented boiloff for LH2 in 'lifting tanks', so we can buff them now
+	
 	@massBuff = #$mixOX$ //Reduction in dry mass for Ox in Hydrolox tanks
 	@massBuff *= 0.005
 	@massBuff *= #$@SMURFFCONFIG/lfomassfactor$
+	temp = #$mixLH2$
+	@temp *= 0.00007085 //density of LqdHydrogen from CRP
+	@temp *= #$@SMURFFCONFIG/LH2massfactor$
+	@massBuff += #$temp$
+	-temp = delete
 	
 	@tankMass1 -= #$massBuff$
 	
-	//The pure LH2 (and LH2 component of hydrolox) are left untouched, to compensate for the lack of boiloff.
+	// Nertea has implemented boiloff for LH2 in 'lifting tanks', so we can buff them now
+
+	@massBuff = #$onlyLH2$
+	@massBuff *= 0.00007085
+	@massBuff *= #$@SMURFFCONFIG/LH2massfactor$
+
+	@tankMass4 -= #$massBuff$
 	
 	@MODULE[InterstellarFuelSwitch]
 	{
@@ -539,11 +595,36 @@ SMURFFCONFIG
 	}
 }
 
-@PART[*]:HAS[@MODULE[InterstellarFuelSwitch],#massPerUnitOX[*],~SMURFFExclude[*rue]]:FOR[zSMURFF] //Cryogenic Engines, LH2 tanks
+// Changing the config values for LH2 to reflect CryoTanks with active cooling, higher starting fraction
+@SMURFFCONFIG:FOR[zSMURFF]
+{
+	// ** LH2 ** /Cryo Tanks
+	
+	@LH2fracstd = 0.441072689 // starts at 44% of tank mass
+
+	@LH2factor = 2 // 
+	@LH2factor != #$tanklever$
+	
+	@LH2minusfactor = 1
+	@LH2minusfactor /= #$LH2factor$
+	@LH2minusfactor -= 1
+	@LH2minusfactor *= -1
+	
+	@LH2massfactor = 1
+	@LH2massfactor = #$LH2minusfactor$
+	@LH2massfactor *= #$LH2fracstd$
+	
+	@LH2reservefactor = 1
+	@LH2reservefactor /= #$LH2factor$
+	@LH2reservefactor *= #$LH2fracstd$
+	
+}
+
+@PART[*]:HAS[@MODULE[InterstellarFuelSwitch],#LH2[*],~SMURFFExclude[*rue]]:FOR[zSMURFF] //Cryogenic Engines, LH2 tanks
 {
 	tankMass0 = #$MODULE[InterstellarFuelSwitch]/tankMass[0,;]$ //LH2
 	tankMass1 = #$MODULE[InterstellarFuelSwitch]/tankMass[1,;]$ //Hydrolox
-	tankMass2 = #$MODULE[InterstellarFuelSwitch]/tankMass[2,;]$ //Ox
+	//tankMass2 = #$MODULE[InterstellarFuelSwitch]/tankMass[2,;]$ //Ox //Nertea's new IFS config has only two tank types for LH2 based tanks
 	
 	%massBuff = #$tankMass0$
 	
@@ -551,23 +632,34 @@ SMURFFCONFIG
 	
 	@tankMass0 -= #$massBuff$
 	@tankMass1 -= #$massBuff$
-	@tankMass2 -= #$massBuff$
+	//@tankMass2 -= #$massBuff$
+
+	@massBuff = #$LH2$
+	@massBuff *= 0.00007085 //density of LqdHydrogen from CRP
+	@massBuff *= #$@SMURFFCONFIG/LH2massfactor$
+
+	@tankMass0 -= #$massBuff$
 	
-	@massBuff = #$mixOX$
-	@massBuff *= #$massPerUnitOX$
-	@massBuff *= #$@SMURFFCONFIG/lfominusfactor$
+	@massBuff = #$mixOX$ //Reduction in dry mass for Ox in Hydrolox tanks
+	@massBuff *= 0.005
+	@massBuff *= #$@SMURFFCONFIG/lfomassfactor$
+	%temp = #$mixLH2$
+	@temp *= 0.00007085 //density of LqdHydrogen from CRP
+	@temp *= #$@SMURFFCONFIG/LH2massfactor$
+	@massBuff += #$temp$
+	-temp = delete
 	
 	@tankMass1 -= #$massBuff$
 	
-	@massBuff = #$OX$
-	@massBuff *= #$massPerUnitOX$
-	@massBuff *= #$@SMURFFCONFIG/lfominusfactor$
+//	@massBuff = #$OX$
+//	@massBuff *= #$massPerUnitOX$
+//	@massBuff *= #$@SMURFFCONFIG/lfominusfactor$
 	
-	@tankMass2 -= #$massBuff$
+//	@tankMass2 -= #$massBuff$
 	
 	@MODULE[InterstellarFuelSwitch]
 	{
-		@tankMass = #$../tankMass0$;$../tankMass1$;$../tankMass2$
+		@tankMass = #$../tankMass0$;$../tankMass1$
 	}
 	
 	%MODULE[ModuleSMURFF]{ }


### PR DESCRIPTION
Updates to account for Nertea's CryoEngines update adding in boiloff of LH2 for all tanks and active cooling to prevent boiloff LH2 in select tanks.

Specific values are preliminary and should be tested and possibly discussed with Nertea.
