### PR TITLE
Update SMURFF.version for 1.3.1

### DIFF
--- a/GameData/SMURFF/SMURFF.version
+++ b/GameData/SMURFF/SMURFF.version
@@ -26,6 +26,6 @@
 	"KSP_VERSION_MAX":{
 		"MAJOR":1,
 		"MINOR":3,
-		"PATCH":0
+		"PATCH":1
 	}
 }


### PR DESCRIPTION
Been playing on a 1.3.1 install for a few days and it seems to be working as expected.