### PR TITLE
add LH2 and LH2+Ox configs for switchable tanks

### DIFF
--- a/GameData/SMURFF/SMURFF.cfg
+++ b/GameData/SMURFF/SMURFF.cfg
@@ -525,6 +525,51 @@ SMURFFCONFIG
 				@unitsPerT *= #$@SMURFFCONFIG/lfofactor$
 			}
 		}
+		@TANK_TYPE_OPTION[LqdHydrogen+Oxidizer]
+		{
+			// mass ratio of LqdHydrogen per mass-unit of Oxidizer
+			fuel_ratio = #$RESOURCE[LqdHydrogen]/unitsPerT$
+			@fuel_ratio *= #$@RESOURCE_DEFINITION[LqdHydrogen]/density$
+			@fuel_ratio /= #$RESOURCE[Oxidizer]/unitsPerT$
+			@fuel_ratio /= #$@RESOURCE_DEFINITION[Oxidizer]/density$
+			fuel_ratio_divider = #$fuel_ratio$
+			@fuel_ratio_divider += 1.0 // mass ratio of Oxidizer per mass-unit of Oxidizer
+			// determine the combined factor by which dry density is adjusted
+			// given that for every unit of mass spend on Oxidizer we also spend
+			// mass on LqdHydrogen
+			lh2_fraction_factor = #$fuel_ratio$
+			@lh2_fraction_factor *= #$@SMURFFCONFIG/lh2liftfactor$
+			@lh2_fraction_factor /= #$fuel_ratio_divider$
+			ox_fraction_factor = 1.0
+			@ox_fraction_factor *= #$@SMURFFCONFIG/lfofactor$
+			@ox_fraction_factor /= #$fuel_ratio_divider$
+			// deleted in special FINAL rule, because otherwise it can't
+			// be used in the RESOURCE adjustments
+			combined_factor = #$lh2_fraction_factor$
+			@combined_factor += #$ox_fraction_factor$
+			-fuel_ratio = delete
+			-fuel_ratio_divider = delete
+			-lh2_fraction_factor = delete
+			-ox_fraction_factor = delete
+
+			@dryDensity /= #$combined_factor$
+			@RESOURCE[LqdHydrogen]
+			{
+				@unitsPerT *= #$../combined_factor$
+			}
+			@RESOURCE[Oxidizer]
+			{
+				@unitsPerT *= #$../combined_factor$
+			}
+		}
+		@TANK_TYPE_OPTION[LqdHydrogen]
+		{
+			@dryDensity /= #$@SMURFFCONFIG/lh2liftfactor$
+			@RESOURCE[LqdHydrogen]
+			{
+				@unitsPerT *= #$@SMURFFCONFIG/lh2liftfactor$
+			}
+		} 
 		@TANK_TYPE_OPTION[RCS]
 		{
 			@dryDensity /= #$@SMURFFCONFIG/monofactor$
@@ -549,7 +594,6 @@ SMURFFCONFIG
 				@unitsPerT *= #$@SMURFFCONFIG/solidfactor$
 			}
 		}
-		
 		@TANK_TYPE_OPTION[Ore]
 		{
 			@dryDensity /= #$@SMURFFCONFIG/orefactor$
@@ -1050,6 +1094,17 @@ SMURFFCONFIG
 		@SUBTYPE,*
 		{
 			@addedMass /= #$@SMURFFCONFIG/lfofactor$
+		}
+	}
+}
+
+@PART[*]:HAS[@MODULE[TankContentSwitcher],~SMURFFExclude[*rue]]:FINAL
+{
+	@MODULE[TankContentSwitcher]
+	{
+		@TANK_TYPE_OPTION[LqdHydrogen+Oxidizer]
+		{
+			-combined_factor = delete
 		}
 	}
 }


### PR DESCRIPTION
The switchable tank used in procedural tanks was not being scaled, this is a nightmare obviously for any kind of attempted SSTO design that used liquid hydrogen.

At some point in time I'd like to have a chat about the dry weight of liquid hydrogen tanks, which are on the heavy side still. But that's a separate discussion from at least bringing the intended scaling behavior also to procedural tanks. Which is what this PR does.