### PR TITLE
Dry weight tweaks

### DIFF
--- a/GameData/SMURFF/SMURFF.cfg
+++ b/GameData/SMURFF/SMURFF.cfg
@@ -154,10 +154,10 @@ SMURFFCONFIG
 	
 	lh2liftfracstd = 0.2 //
 	
-	// Goal: get to LH2 tank mass = 30%, which is based of Ariane H-173 (see https://www.nasa.gov/pdf/382034main_018%20-%2020090706.05.Analysis_of_Propellant_Tank_Masses.pdf) combined LH2+LOx ratio of ~7%
+	// Goal: get to LH2 tank mass = 28.6%, which is based of Ariane H-173 (see https://www.nasa.gov/pdf/382034main_018%20-%2020090706.05.Analysis_of_Propellant_Tank_Masses.pdf) combined LH2+LOx ratio of 6.86% (which applies to its Vulcain 2 engine)
 	// Note that this is biased towards modern larger rocket tanks weighing at least 150.000 kg which is very common if you play Real Solar System (scale)
 	// this degrades in the direction of 40% for smaller tanks that you might find on third stages
-	lh2liftfactor = 0.66
+	lh2liftfactor = 0.70
 	@lh2liftfactor != #$tanklever$
 	
 	lh2liftminusfactor = 1
@@ -177,7 +177,7 @@ SMURFFCONFIG
 	
 	lh2zbofracstd = 0.2 //
 	
-	lh2zbofactor = 0.66 // Matching non-zbo LH2 tanks...changed my mind for gameplay purposes.
+	lh2zbofactor = 0.70 // Matching non-zbo LH2 tanks...changed my mind for gameplay purposes.
 	// Was:
 	// lh2zbofactor = 0.172 // Goal: get to LH2 tank mass = 1.16x fuel mass (making them *heavier*!  LH2 is super fluffy...), ref: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20030067928.pdf -- mass of the power hardware is not included, so there's a bit of a win there.
 	@lh2zbofactor != #$tanklever$

--- a/GameData/SMURFF/SMURFF.cfg
+++ b/GameData/SMURFF/SMURFF.cfg
@@ -154,7 +154,10 @@ SMURFFCONFIG
 	
 	lh2liftfracstd = 0.2 //
 	
-	lh2liftfactor = 0.71 // Goal: get to LH2 tank mass = 28.2% fuel mass (making them *heavier*!  LH2 is super fluffy...)
+	// Goal: get to LH2 tank mass = 30%, which is based of Ariane H-173 (see https://www.nasa.gov/pdf/382034main_018%20-%2020090706.05.Analysis_of_Propellant_Tank_Masses.pdf) combined LH2+LOx ratio of ~7%
+	// Note that this is biased towards modern larger rocket tanks weighing at least 150.000 kg which is very common if you play Real Solar System (scale)
+	// this degrades in the direction of 40% for smaller tanks that you might find on third stages
+	lh2liftfactor = 0.66
 	@lh2liftfactor != #$tanklever$
 	
 	lh2liftminusfactor = 1
@@ -174,7 +177,7 @@ SMURFFCONFIG
 	
 	lh2zbofracstd = 0.2 //
 	
-	lh2zbofactor = 0.71 // Matching non-zbo LH2 tanks...changed my mind for gameplay purposes.
+	lh2zbofactor = 0.66 // Matching non-zbo LH2 tanks...changed my mind for gameplay purposes.
 	// Was:
 	// lh2zbofactor = 0.172 // Goal: get to LH2 tank mass = 1.16x fuel mass (making them *heavier*!  LH2 is super fluffy...), ref: http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20030067928.pdf -- mass of the power hardware is not included, so there's a bit of a win there.
 	@lh2zbofactor != #$tanklever$

--- a/plot_dry_wet_mass_ratio.py
+++ b/plot_dry_wet_mass_ratio.py
@@ -1,0 +1,43 @@
+#!/bin/python
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+density_lh2 = 0.071 # kg/L
+density_lox = 1.141 # kg/L
+
+mass_ratio_lox_lh2 = 7 # this is dependent on how fuel rich the engine is burning, according to H2 + O2 -> H2O you would get 8, but then you have "hot-oxygen" problems and no cooling of nozzle by fuel
+volume_lh2 = 1
+volume_lox = mass_ratio_lox_lh2 * (density_lh2/density_lox)
+volume_ratio_lox_lh2 = volume_lox/volume_lh2
+
+print('Volume lh2 per liter of fuel {}'.format(volume_lh2))
+print('Volume lox per liter of fuel {}'.format(volume_lox))
+
+# dry-wet ratio: tank mass/(tank mass + propellant mass)
+mass_per_liter_of_lh2_tank = np.linspace(0.001, 0.1, 100)
+mass_of_lox_tank_per_liter_of_lh2 = mass_per_liter_of_lh2_tank * volume_ratio_lox_lh2
+mass_of_combined_fuel_tanks = mass_per_liter_of_lh2_tank + mass_of_lox_tank_per_liter_of_lh2
+
+mass_of_lox_per_liter_of_lh2 = density_lox * volume_ratio_lox_lh2
+mass_of_combined_fuel_per_liter_of_lh2 = mass_of_lox_per_liter_of_lh2 + density_lh2
+
+print('Mass of one liter of LH2 {}'.format(density_lh2))
+print('Mass of corresponding amount of LOx {}'.format(mass_of_lox_per_liter_of_lh2))
+print('Combined mass per one liter of LH2 {}'.format(mass_of_combined_fuel_per_liter_of_lh2))
+
+dry_wet_ratio_lh2 = mass_per_liter_of_lh2_tank/(mass_per_liter_of_lh2_tank + density_lh2)
+dry_wet_ratio_lox = mass_of_lox_tank_per_liter_of_lh2/(mass_of_lox_tank_per_liter_of_lh2 + mass_of_lox_per_liter_of_lh2)
+dry_wet_ratio_combined = mass_of_combined_fuel_tanks/(mass_of_combined_fuel_tanks + mass_of_combined_fuel_per_liter_of_lh2)
+
+
+ax = plt.axes()
+ax.semilogy(mass_per_liter_of_lh2_tank, dry_wet_ratio_lh2 * 100, label='lh2')
+ax.semilogy(mass_per_liter_of_lh2_tank, dry_wet_ratio_lox * 100, label='lox')
+ax.semilogy(mass_per_liter_of_lh2_tank, dry_wet_ratio_combined * 100, label='lh2+lox')
+ax.set(xlabel='mass of tank per liter of LH2 in kg',
+       ylabel='dry-wet ratio of tank (percentage)')
+ax.legend()
+ax.grid(True, which='both')
+ax.set_title('Dry-wet mass ratios for LH2 and LOx tanks')
+plt.show()

--- a/plot_dry_wet_mass_ratio.py
+++ b/plot_dry_wet_mass_ratio.py
@@ -3,10 +3,41 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
+# For literature comparison we always want to base ourselves on real life LH2+LOx combination
+# The point is to figure out the dry-wet mass ratio for LH2 from literature that typically considers all propellants together
+# So we assume that the tanks for LH2 and LOx are equal, but that LH2 is far less dense, and calculate from that the dry-wet ratio of LH2 tanks
 density_lh2 = 0.071 # kg/L
 density_lox = 1.141 # kg/L
 
-mass_ratio_lox_lh2 = 7 # this is dependent on how fuel rich the engine is burning, according to H2 + O2 -> H2O you would get 8, but then you have "hot-oxygen" problems and no cooling of nozzle by fuel
+# In KSP:
+# Oxidizer has a density of 0.005 metric tonnes/5L, or 0.001 metric tonnes/L, or 1 kg/L
+# LqdHydrogen has a density of 0.00007085 metric tonnes/L, or 0.07085 kg/L
+# CryoTanks engines run in a ratio of 15:1 units, so 15 liter of LqdHydrogen for every 5 liters of Oxidizer
+
+# Oxider can be many things, for example:
+# LOx: then all the mass is oxygen
+# N2O4: then 4*16/(2*14+4*16) = 69.6% is oxygen
+
+# LOx would make the most sense for LH2, but this is KSP, and Oxidizer doesn't boiloff
+# Note that all cited resources will use LOx, so the plotting will always talk about LOx, because we are interested in the LH2 part of the tanks
+# Mass ratio when Oxidizer is LOx: (1*5)/(0.07085*15) = 4.705
+# Mass ratio when Oxidizer is N2O4: (1*5)/(0.07085*15*0.696) = 6.760
+# Density wise neither of two match 1 kg/L, LOx being the least dense of them all
+# And choosing either of these two extreme answers is a bit weird, because 4.705 is extremely fuel rich, not applied typically at all, but 6.670 is for state of the art engines
+# If we look at the actual density LOx has the lowest density of all the oxidizers
+# KSP probably made a bit a random choice given the rounded number
+
+# The fun thing is this whole consideration doesn't matter
+# Because are only interesting in the dry-mass of LH2 tanks for a real rocket
+# A real rocket tank runs at a predefined ratio for that given engine design
+# Thus includes a predefined ratio of LH2 and LOx in its tanks, thus also the combined dry-wet mass ratio
+# This will tell us what a decent load-bearing tank is like (the shuttle external tank is not part of the main structure)
+
+# The Arianne H-173 stage has a dry-wet ratio of 6.86% (see https://www.nasa.gov/pdf/382034main_018%20-%2020090706.05.Analysis_of_Propellant_Tank_Masses.pdf)
+# It uses a Vulcain 2 engine, with a fuel to oxidizer ratio of 6.7 (http://www.astronautix.com/v/vulcain2.html)
+
+mass_ratio_lox_lh2 = 6.7 # this is dependent on how fuel rich the engine is burning, according to H2 + O2 -> H2O you would get 8, but then you have "hot-oxygen" problems and no cooling of nozzle by fuel
+desired_combined_dry_wet_ratio = 0.0686
 volume_lh2 = 1
 volume_lox = mass_ratio_lox_lh2 * (density_lh2/density_lox)
 volume_ratio_lox_lh2 = volume_lox/volume_lh2
@@ -15,7 +46,7 @@ print('Volume lh2 per liter of fuel {}'.format(volume_lh2))
 print('Volume lox per liter of fuel {}'.format(volume_lox))
 
 # dry-wet ratio: tank mass/(tank mass + propellant mass)
-mass_per_liter_of_lh2_tank = np.linspace(0.001, 0.1, 100)
+mass_per_liter_of_lh2_tank = np.linspace(0.001, 0.1, 1000)
 mass_of_lox_tank_per_liter_of_lh2 = mass_per_liter_of_lh2_tank * volume_ratio_lox_lh2
 mass_of_combined_fuel_tanks = mass_per_liter_of_lh2_tank + mass_of_lox_tank_per_liter_of_lh2
 
@@ -30,6 +61,13 @@ dry_wet_ratio_lh2 = mass_per_liter_of_lh2_tank/(mass_per_liter_of_lh2_tank + den
 dry_wet_ratio_lox = mass_of_lox_tank_per_liter_of_lh2/(mass_of_lox_tank_per_liter_of_lh2 + mass_of_lox_per_liter_of_lh2)
 dry_wet_ratio_combined = mass_of_combined_fuel_tanks/(mass_of_combined_fuel_tanks + mass_of_combined_fuel_per_liter_of_lh2)
 
+first_index_where_dry_wet_ratio_combined_exceeds_desired_value = np.where(dry_wet_ratio_combined > desired_combined_dry_wet_ratio)[0][0]
+print('Dry-wet ratio mass ratio of LH2 tank {}% at a combined ratio {}%'.format(dry_wet_ratio_lh2[first_index_where_dry_wet_ratio_combined_exceeds_desired_value],
+                                                                                dry_wet_ratio_combined[first_index_where_dry_wet_ratio_combined_exceeds_desired_value]))
+print('Dry-wet ratio mass ratio of LOx tank {}% at a combined ratio {}, note that Oxidizer is not garuanteed to be LOx, and this only applies to a rocket running a fuel to oxidizer ratio of {}, so applicability is limited'.format(
+                                                                                dry_wet_ratio_lox[first_index_where_dry_wet_ratio_combined_exceeds_desired_value],
+                                                                                dry_wet_ratio_combined[first_index_where_dry_wet_ratio_combined_exceeds_desired_value],
+                                                                                mass_ratio_lox_lh2))
 
 ax = plt.axes()
 ax.semilogy(mass_per_liter_of_lh2_tank, dry_wet_ratio_lh2 * 100, label='lh2')

--- a/plot_dry_wet_mass_ratio.py
+++ b/plot_dry_wet_mass_ratio.py
@@ -28,7 +28,7 @@ density_lox = 1.141 # kg/L
 # KSP probably made a bit a random choice given the rounded number
 
 # The fun thing is this whole consideration doesn't matter
-# Because are only interesting in the dry-mass of LH2 tanks for a real rocket
+# Because we are only interesting in the dry-mass of LH2 tanks for a real rocket
 # A real rocket tank runs at a predefined ratio for that given engine design
 # Thus includes a predefined ratio of LH2 and LOx in its tanks, thus also the combined dry-wet mass ratio
 # This will tell us what a decent load-bearing tank is like (the shuttle external tank is not part of the main structure)


### PR DESCRIPTION
Much to my surprise the LH2 dry weight was actually a bit on the low side. Because I expected actually much lighter tanks, I added both a reference and a script that can be used plot dry-wet weight ratios for lh2, lox and combined.