### PR TITLE
Add patches for Kerbal Atomics

### DIFF
--- a/GameData/SMURFF/SMURFF.cfg
+++ b/GameData/SMURFF/SMURFF.cfg
@@ -743,6 +743,35 @@ SMURFFCONFIG
 	}
 }
 
+// Atomic Engines
+@PART[*]:HAS[@MODULE[ModuleEnginesFX]:HAS[@PROPELLANT[LqdHydrogen],!PROPELLANT[Oxidizer]],!MODULE[ModuleCommand],~CrewCapacity[>0],!MODULE[ModuleCargoBay],!MODULE[ModuleSMURFF],~SMURFFExclude[*rue]]:FOR[zzz_SMURFF]
+{
+	@mass *= #$@SMURFFCONFIG/enginemassfactor$
+
+	@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LqdHydrogen],!PROPELLANT[Oxidizer]],*
+	{
+		@maxThrust *= #$@SMURFFCONFIG/enginethrustfactor$
+		@minThrust *= #$@SMURFFCONFIG/enginethrustfactor$
+	}
+
+	@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel],!PROPELLANT[Oxidizer]],*
+	{
+		@maxThrust *= #$@SMURFFCONFIG/enginethrustfactor$
+		@minThrust *= #$@SMURFFCONFIG/enginethrustfactor$
+	}
+
+	@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LqdHydrogen],@PROPELLANT[Oxidizer]],*
+	{
+		@maxThrust *= #$@SMURFFCONFIG/enginethrustfactor$
+		@minThrust *= #$@SMURFFCONFIG/enginethrustfactor$
+	}
+	
+	MODULE
+	{
+		name = ModuleSMURFF
+	}
+}
+
 @PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[Oxidizer]],!MODULE[ModuleSMURFF],~SMURFFExclude[*rue]]:FOR[zzz_SMURFF] // And now the engines that weren't buffed because they are probe cores, cargo bays, or multimode engines with non-Oxidizer-burning modes.
 {
 	@MODULE[ModuleEngines*]:HAS[@PROPELLANT[Oxidizer]],*


### PR DESCRIPTION
Hi. I made patch for nuclear thermal rockets. It affects engines that have mode which uses hydrogen only, then it patches LF, Hydrogen and HydroOxi modes with increased thrust and overall decreased weight.
Possible issue: fusion engines.